### PR TITLE
Fix typo in examples

### DIFF
--- a/docs/assets/pug/examples.pug
+++ b/docs/assets/pug/examples.pug
@@ -366,7 +366,7 @@ html(lang="en")
                             pre
                                 code.language-css
                                     | .canvas-interactive-wrapper {
-                                    |     position: relative
+                                    |     position: relative;
                                     |     height: 300px;
                                     |     text-align: center;
                                     | }

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -374,7 +374,7 @@ function setClass(element) {
             </div>
             <div class="tab" id="interactive-css" data-toggle="pill">
               <pre><code class="language-css">.canvas-interactive-wrapper {
-    position: relative
+    position: relative;
     height: 300px;
     text-align: center;
 }


### PR DESCRIPTION
Forget a semicolon.